### PR TITLE
Packman not creating package files.

### DIFF
--- a/Source/Tools/Packman/Installers.pas
+++ b/Source/Tools/Packman/Installers.pas
@@ -101,7 +101,7 @@ begin
 
       if not DirectoryExists(ExtractFileDir(TheFile.Dest)) then
           Mkdir(ExtractFileDir(TheFile.Dest));
-      CopyFile(PChar(TheFile.Source), PChar(TheFile.Dest), False);
+      CopyFile(PChar(String(TheFile.Source)), PChar(String(TheFile.Dest)), False);
 
       if (IMod = 0) or (i mod IMod = 0) then
           Application.ProcessMessages;


### PR DESCRIPTION
Package files were not being created on disk (confirmed by the Package Verify function).
The call to CopyFile has a cast from AnsiString to PChar (PwideChar) that needs to cast to String first.

I tested this change with the Dev-Cpp 5.5 code base, as I haven't installed the SVG components yet.
The packages were targeted to : C:\Work\GitHub\bin\ . . .

Running Dev-Cpp 6.2, it seems to be targeting :  C:\Program Files (x86)\Embarcadero\Dev-Cpp\ . . .
I don't know if the program will have the privileges to create files in there.
It does currently manage to create (eg) : C:\Program Files (x86)\Embarcadero\Dev-Cpp\Packages\zlib.entry

I've tested with several DevPaks.  eg  https://sourceforge.net/projects/devpaks/files/zlib/zlib%201.2.3/